### PR TITLE
change overflow from scroll to auto

### DIFF
--- a/src/pages/documentation/index.scss
+++ b/src/pages/documentation/index.scss
@@ -139,7 +139,7 @@
         padding: 8px;
         background-color: $dark-blue;
         color: $white;
-        overflow: scroll;
+        overflow: auto;
         font-size: 14px;
 
         @include respond-to-min($desktop) {

--- a/src/pages/home/index.scss
+++ b/src/pages/home/index.scss
@@ -275,7 +275,7 @@
         position: relative;
         height: auto;
         background-color: $dark-blue;
-        overflow: scroll;
+        overflow: auto;
 
         @include respond-to-min($tablet-large) {
             grid-column: 1 / 5;
@@ -299,7 +299,7 @@
         pre { 
             padding: 1em;
             margin: 0;
-            overflow: scroll;
+            overflow: auto;
             color: $white;
         }
 


### PR DESCRIPTION
since scroll and auto are functionally the same with the only difference being scroll always shows the scrollbars even without clipped content, change to auto to enhance the look by hiding the browsers scrollbars when not required