### PR TITLE
Make documentation highlight link functional

### DIFF
--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -31,6 +31,7 @@ const stateReducer = (state = initialState, {type, payload}) => {
 const events = bindEvents({
     docsLink: {
         click(event, {props}) {
+            event.preventDefault();
             props.changeRoute('/documentation');
         }
     }

--- a/src/pages/home/index.twig
+++ b/src/pages/home/index.twig
@@ -105,7 +105,7 @@
                     <code class="hero__code-block--comment"># Create a Melody app</code>
                     <code>yarn create melody-app my-app</code>
                 </div>
-                <p class="hero__paragraph">Dive deeper and read the <a class="highlight">documentation</a></p>
+                <p class="hero__paragraph">Dive deeper and read the <a class="highlight" href="/documentation" ref="{{docsLink}}">documentation</a></p>
             </div>
         </section>
     </div>


### PR DESCRIPTION
the documentation link at the bottom of the front page is highlighted but not functional (just like the 5 mins tutorial link but i have no idea where the video is…)

these changes make it functional.

NOTE:
i dont know if it is "good" to use a ref with the same name multiple times, if not, just create a new one with the current config and remove the preventDefault from the button since its not needed there…