### PR TITLE
add condition for not adding attributes

### DIFF
--- a/docs/docs/twig/attributes.md
+++ b/docs/docs/twig/attributes.md
@@ -78,5 +78,6 @@ In this case, the `checked` attribute will only be added if the `isChecked` prop
 * its value is `false`
 * its value is `undefined`
 * its value is `null`
+* its value is `''`
 * it was previously specified on the element in question
 


### PR DESCRIPTION
given `{{ foo ? 'yes' }} is the same as {{ foo ? 'yes' : '' }}` in case `"role": addRole ? "textbox",`, `role` will not be added at all because its value would be `''`