### PR TITLE
fixed "the the" typo

### DIFF
--- a/docs/docs/advanced/hoc.md
+++ b/docs/docs/advanced/hoc.md
@@ -217,7 +217,7 @@ export default enhance(MyComponent);
 
 Specifies a redux store and passes two additional props to the base component: a state value, and a function to dispatch actions.
 You'll likely want to use this state updater along with `withHandlers` to create specific updater functions.
-When props are given the the component the `RECEIVE_PROPS` action will be called with the props as its `payload`.
+When props are given to the component, the `RECEIVE_PROPS` action will be called with the props as its `payload`.
 
 ### Signature
 ```


### PR DESCRIPTION
Reference issue for this pull request: [Several typos in Higher order components documentation #15](https://github.com/trivago/melody-web/issues/15).   

Partial fix:  "given the the component"   should read "given to the component," 